### PR TITLE
[FIX] sale_order_blanket_order_stock_prebook_release: fix date validation error handling on blanket order confirm.

### DIFF
--- a/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
+++ b/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
@@ -27,7 +27,11 @@ class SaleOrder(models.Model):
         the confirmation date by blanket_validity_start_date.
         This method is called at the start of the confirmation process.
         """
-        blankets = self.filtered(lambda o: o.order_type == "blanket")
+
+        # ensure validity_start_date is set otherwise sql query will fail
+        blankets = self.filtered(
+            lambda o: o.order_type == "blanket" and o.blanket_validity_start_date
+        )
         # we need to query the count of confirmed blanket orders for each
         # blanket_validity_start_date
         if not blankets:

--- a/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
+++ b/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import freezegun
 
 from odoo import Command
+from odoo.exceptions import ValidationError
 
 from .common import SaleOrderBlanketOrderStockPrebookReleaseCase
 
@@ -169,3 +170,18 @@ class TestSaleOrderBlanketOrderStockPrebookRelease(
             self.assertEqual(
                 move.date_priority, self.blanket_so.blanket_move_date_priority
             )
+
+    def test_confirm_dates_validation_not_broken_on_confirm(self):
+        """Ensure the dates validation occurs when confirming a blanket order.
+
+        This unit test addresses a bug where a computed field's calculation was
+        triggered before essential date validation (defined by @api.constrains).
+        The bug arose because the compute method did not account for potentially
+        empty date fields, leading to a stack trace in the UI instead of a nice
+        Validation Error pop up.
+        """
+        self.blanket_so.write(
+            {"blanket_validity_start_date": False, "blanket_validity_end_date": False}
+        )
+        with self.assertRaises(ValidationError):
+            self.blanket_so.action_confirm()


### PR DESCRIPTION
Prevents a stack trace from being displayed to the user when confirming a blanket order without required validity dates.

The issue arose because a compute field's raw SQL query accessed date fields before the dates were validated. Since the query didn't check for unset dates, it would fail when encountering empty values.