### PR TITLE
[IMP] sale_order_blanket_order_stock_prebook_release: Synchronize out moves priority dates on blanket order date change

### DIFF
--- a/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
+++ b/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
@@ -27,7 +27,11 @@ class SaleOrder(models.Model):
         the confirmation date by blanket_validity_start_date.
         This method is called at the start of the confirmation process.
         """
-        blankets = self.filtered(lambda o: o.order_type == "blanket")
+
+        # ensure validity_start_date is set otherwise sql query will fail
+        blankets = self.filtered(
+            lambda o: o.order_type == "blanket" and o.blanket_validity_start_date
+        )
         # we need to query the count of confirmed blanket orders for each
         # blanket_validity_start_date
         if not blankets:

--- a/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
+++ b/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import timedelta
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -12,6 +12,8 @@ class SaleOrder(models.Model):
         string="Move Date Priority",
         help="Date priority for the moves of the order.",
     )
+
+    commitment_date = fields.Datetime(compute="_compute_commitment_date", store=True)
 
     def action_confirm(self):
         self.flush_recordset()
@@ -63,3 +65,26 @@ class SaleOrder(models.Model):
                 start_date
             ) + timedelta(seconds=order_position)
             count_per_date[start_date] = order_position + 1
+
+    @api.depends("blanket_validity_start_date")
+    def _compute_commitment_date(self):
+        blanket_orders = self.filtered(
+            lambda o: o.order_type == "blanket" and o.state != "draft"
+        )
+        if not blanket_orders:
+            return
+
+        for order in blanket_orders:
+            order.commitment_date = order.blanket_validity_start_date
+
+        blanket_orders._compute_blanket_move_date_priority()
+
+        out_moves = self.env["stock.move"].search(
+            [
+                ("sale_line_id.order_id", "in", self.ids),
+                ("state", "not in", ("done", "cancel")),
+                ("picking_type_id.code", "=", "outgoing"),
+            ]
+        )
+        for move in out_moves:
+            move.date_priority = move.sale_line_id.order_id.blanket_move_date_priority

--- a/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
+++ b/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import timedelta
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class SaleOrder(models.Model):
@@ -13,7 +13,11 @@ class SaleOrder(models.Model):
         help="Date priority for the moves of the order.",
     )
 
-    commitment_date = fields.Datetime(compute="_compute_commitment_date", store=True)
+    commitment_date = fields.Datetime(inverse="_inverse_commitment_date")
+
+    blanket_validity_start_date = fields.Date(
+        inverse="_inverse_blanket_validity_start_date"
+    )
 
     def action_confirm(self):
         self.flush_recordset()
@@ -66,12 +70,31 @@ class SaleOrder(models.Model):
             ) + timedelta(seconds=order_position)
             count_per_date[start_date] = order_position + 1
 
-    @api.depends("blanket_validity_start_date")
-    def _compute_commitment_date(self):
+    def _inverse_commitment_date(self):
         blanket_orders = self.filtered(
             lambda o: o.order_type == "blanket" and o.state != "draft"
         )
-        if not blanket_orders:
+        blanket_orders.with_context(from_inverse_commitment_date=True)
+
+        # Ensure we do not get back into the "_inverse_blanket_validity_start_date"
+        # since this would trigger "_compute_blanket_move_date_priority" and this
+        # would mess with the date priority
+        for blanket_order in blanket_orders:
+            blanket_order.with_context(from_inverse_commitment_date=True).write(
+                {"blanket_validity_start_date": blanket_order.commitment_date}
+            )
+
+    def _inverse_blanket_validity_start_date(self):
+        """
+        Update the commitment date to the new start date +
+        refresh related ongoing out moves date priority
+        """
+        blanket_orders = self.filtered(
+            lambda o: o.order_type == "blanket" and o.state != "draft"
+        )
+        if not blanket_orders or blanket_orders._context.get(
+            "from_inverse_commitment_date"
+        ):
             return
 
         for order in blanket_orders:
@@ -81,7 +104,7 @@ class SaleOrder(models.Model):
 
         out_moves = self.env["stock.move"].search(
             [
-                ("sale_line_id.order_id", "in", self.ids),
+                ("sale_line_id.order_id", "in", blanket_orders.ids),
                 ("state", "not in", ("done", "cancel")),
                 ("picking_type_id.code", "=", "outgoing"),
             ]

--- a/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
+++ b/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
@@ -1,7 +1,7 @@
 # Copyright 2025 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from datetime import datetime
+from datetime import date, datetime
 
 import freezegun
 
@@ -170,6 +170,42 @@ class TestSaleOrderBlanketOrderStockPrebookRelease(
             self.assertEqual(
                 move.date_priority, self.blanket_so.blanket_move_date_priority
             )
+
+    @freezegun.freeze_time("2025-01-01 00:00:00")
+    def test_date_priority_after_blanket_validity_start_date_change(self):
+        self.blanket_so.action_confirm()
+        self.assertEqual(self.blanket_so.blanket_validity_start_date, date(2025, 1, 1))
+        self.assertEqual(self.blanket_so.commitment_date.date(), date(2025, 1, 1))
+        call_off_so = self.env["sale.order"].create(
+            {
+                "order_type": "call_off",
+                "date_order": "2025-02-01",
+                "partner_id": self.partner_delta.id,
+                "blanket_order_id": self.blanket_so.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product1.id,
+                            "product_uom_qty": 10.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        call_off_so.action_confirm()
+
+        picking = call_off_so.order_line.blanket_move_ids.picking_id
+        picking.action_assign()
+        out_moves = picking.move_ids
+        self.assertEqual(
+            out_moves.date_priority.date(), self.blanket_so.blanket_validity_start_date
+        )
+
+        self.blanket_so.blanket_validity_start_date = date(2025, 1, 2)
+        self.assertEqual(self.blanket_so.commitment_date.date(), date(2025, 1, 2))
+        self.assertEqual(
+            out_moves.date_priority.date(), self.blanket_so.blanket_validity_start_date
+        )
 
     def test_confirm_dates_validation_not_broken_on_confirm(self):
         """Ensure the dates validation occurs when confirming a blanket order.

--- a/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
+++ b/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import freezegun
 
 from odoo import Command
+from odoo.exceptions import ValidationError
 
 from .common import SaleOrderBlanketOrderStockPrebookReleaseCase
 
@@ -169,3 +170,18 @@ class TestSaleOrderBlanketOrderStockPrebookRelease(
             self.assertEqual(
                 move.date_priority, self.blanket_so.blanket_move_date_priority
             )
+
+    def test_confirm_dates_validation_not_broken_on_confirm(self):
+        """Ensure the dates validation occurs when confirming a blanket order.
+
+        This unit test addresses a bug where a computed field's calculation was
+        triggered before essential date validation (defined by @api.constrains).
+        The bug arose because the compute method did not account for potentially
+        empty date fields, leading to a stack trace in the UI instead of a nice
+        Validation Error pop up.
+        """
+        self.blanket_so.write(
+            {"blanket_validity_start_date": False, "blanket_validity_end_date": False}
+        )
+        with self.assertRaises(ValidationError):
+            self.blanket_so.action_confirm()


### PR DESCRIPTION
Ensures consistency of related output moves' `date_priority` when a blanket order's validity dates are modified after confirmation.

This PR is based on: https://github.com/OCA/sale-blanket/pull/7