### PR TITLE
[16.0][FIX] ale_order_blanket_order: Correctly display boolean toggle

### DIFF
--- a/sale_order_blanket_order/views/sale_order.xml
+++ b/sale_order_blanket_order/views/sale_order.xml
@@ -85,7 +85,7 @@
                     attrs="{'invisible': [('order_type', '!=', 'blanket')], 'readonly': [('is_blanket_eol_strategy_editable', '=', False)]}"
                 />
             </field>
-            <field name="commitment_date" position="after">
+            <field name="manual_delivery" position="after">
                 <field
                     name="create_call_off_from_so_if_possible"
                     widget="boolean_toggle"


### PR DESCRIPTION
Moves the `create_call_off_from_so_if_possible` boolean field to its own line to properly display its label and prevent it from appearing on the same line as the `commitment_date` field. This resolves a rendering issue caused by incorrect placement within an `o_row` div.

**Before:**
<img width="1038" height="866" alt="image" src="https://github.com/user-attachments/assets/2bf88b52-4ace-40ae-a027-99f5b9d96a17" />

**After:**
<img width="1038" height="866" alt="image" src="https://github.com/user-attachments/assets/a31aebc2-1256-4921-b7fe-2d3474e8cb1f" />
