### PR TITLE
[18.0][FIX] sale_blanket_order: restore view deleted by mistake during migration

### DIFF
--- a/sale_blanket_order/views/sale_order_views.xml
+++ b/sale_blanket_order/views/sale_order_views.xml
@@ -11,6 +11,16 @@
             <xpath expr="//field[@name='order_line']" position="attributes">
                 <attribute name="context">{'from_sale_order': True}</attribute>
             </xpath>
+            <xpath
+                expr="//field[@name='order_line']//list/field[@name='product_template_id']"
+                position="after"
+            >
+                <field
+                    name="blanket_order_line"
+                    context="{'from_sale_order': True}"
+                    column_invisible="not parent.blanket_order_id"
+                />
+            </xpath>
         </field>
     </record>
     <record id="view_order_form_disable_adding_lines" model="ir.ui.view">


### PR DESCRIPTION
* See blanket order in the sale lines from sale form view 
* ~~Add the attribute to disable adding lines on the same view~~

@LauraCForgeFlow 

The views were deleted by mistake in https://github.com/OCA/sale-blanket/pull/8/commits/24117c27038f2c9803c3cb033d33fe2db8a733b1

In v17 they are there: https://github.com/OCA/sale-workflow/blob/17.0/sale_blanket_order/views/sale_order_views.xml#L11