### PR TITLE
[18.0][FIX] sale_blanket_order: missing field company_id in blanket order wizard lines

### DIFF
--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -232,3 +232,6 @@ class BlanketOrderWizardLine(models.TransientModel):
         "res.partner", related="blanket_line_id.partner_id", string="Vendor"
     )
     taxes_id = fields.Many2many("account.tax", related="blanket_line_id.taxes_id")
+    company_id = fields.Many2one(
+        "res.company", related="blanket_line_id.company_id", string="Company"
+    )


### PR DESCRIPTION
**Edit: found the root cause**. Since this change all the models that inherits from the analytic.mixin must have the field company_id defined: https://github.com/odoo/odoo/commit/3831c4183bc7dbd370e13d3c9de4a55a5d51bbfd#diff-5d40d513c23496ddfa20f44310ffbbee7d0bfb1d8563b687745bc74e1682c745R689


<img width="439" height="192" alt="image" src="https://github.com/user-attachments/assets/3fb93f80-c010-4573-8f75-cec738c8a6c4" />


```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2144, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 156, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2111, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 2359, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/web/controllers/dataset.py", line 36, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "/opt/odoo/auto/addons/web/models/models.py", line 902, in onchange
    field = lines._fields[field_name]
KeyError: 'company_id'
```