### PR TITLE
[18.0][FIX] sale_blanket: disable_adding_lines kanban

### DIFF
--- a/sale_blanket_order/static/src/js/disable_add_order_line.esm.js
+++ b/sale_blanket_order/static/src/js/disable_add_order_line.esm.js
@@ -1,5 +1,5 @@
-import {KanbanRenderer} from "@web/views/kanban/kanban_renderer";
 import {ListRenderer} from "@web/views/list/list_renderer";
+import {SaleOrderLineOne2Many} from "@sale/js/sale_order_line_field/sale_order_line_field";
 import {patch} from "@web/core/utils/patch";
 
 patch(ListRenderer.prototype, {
@@ -10,17 +10,13 @@ patch(ListRenderer.prototype, {
     },
 });
 
-patch(KanbanRenderer.prototype, {
-    get canCreate() {
-        const parent = this.props.list.model.root;
-        const parentModel = parent?.resModel || parent?.model;
-        const fieldName = this.props.arch.attrs.name;
-
-        if (parentModel === "sale.order" && fieldName === "order_line") {
-            const disabled = parent.data?.disable_adding_lines;
-            return !disabled && super.canCreate;
+patch(SaleOrderLineOne2Many.prototype, {
+    get displayControlPanelButtons() {
+        const fieldName = this.props.name;
+        if (this.props.viewMode === "kanban" && fieldName === "order_line") {
+            const disabled = this.props.record?.data?.disable_adding_lines;
+            return !disabled && super.displayControlPanelButtons;
         }
-
-        return super.canCreate;
+        return super.displayControlPanelButtons;
     },
 });


### PR DESCRIPTION
This disable adding lines condition wasn't computed correctly, and users could always add lines to the SO when the SO lines were displayed in kanban view. This PR fixes that behavior, lines to be added only when the logic and the conditions allow it.