### PR TITLE
[18.0][FIX] sale_blanket_order: SOL price unit recomputation

### DIFF
--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -126,28 +126,6 @@ class SaleOrderLine(models.Model):
 
     @api.onchange("product_uom", "product_uom_qty")
     def product_uom_change(self):
-        if not self.product_uom or not self.product_id:
-            self.price_unit = 0.0
-            return
-        if self.order_id.pricelist_id and self.order_id.partner_id:
-            product = self.product_id.with_context(
-                lang=self.order_id.partner_id.lang,
-                partner=self.order_id.partner_id,
-                quantity=self.product_uom_qty,
-                date=self.order_id.date_order,
-                pricelist=self.order_id.pricelist_id.id,
-                uom=self.product_uom.id,
-                fiscal_position=self.env.context.get("fiscal_position"),
-            )
-            self.price_unit = product._get_tax_included_unit_price(
-                self.company_id or self.order_id.company_id,
-                self.order_id.currency_id,
-                self.order_id.date_order,
-                "sale",
-                fiscal_position=self.order_id.fiscal_position_id,
-                product_price_unit=self._get_display_price(),
-                product_currency=self.order_id.currency_id,
-            )
         if self.product_id and not self.env.context.get("skip_blanket_find", False):
             return self.get_assigned_bo_line()
         return


### PR DESCRIPTION
The recomputation of the `price_unit` field inside the `product_uom_change` in this module is incorrect since the method used to compute the value of the field is not coherent with the actual behavior in Odoo's [`sale` module](https://github.com/odoo/odoo/blob/a1f87db3548242715040c480745756c967562526/addons/sale/models/sale_order_line.py#L562), it does not take into account the manual price setting, the force recompute context...

We remove this whole code fragment since the computation of this field is already handled by the `sale` module, in the mentioned `_compute_price_unit` method. The dependencies cover the ones in the `product_uom_change` function so it will be executed or triggered in the same situations, but using the correct logic. Also note this was the original behavior of the module back in [version 15.0](https://github.com/OCA/sale-workflow/blob/0f9c68c9233fb7da7ad8a7e406f56455c3bfd3fd/sale_blanket_order/models/sale_orders.py#L115C5-L115C34) and earlier, the price computation logic was not implemented in this module.