### PR TITLE
[16.0][FIX] sale_order_blanket_order: Ensures registry consistency on asser…

### DIFF
--- a/sale_order_blanket_order/tests/test_sale_blanket_order.py
+++ b/sale_order_blanket_order/tests/test_sale_blanket_order.py
@@ -87,7 +87,7 @@ class TestSaleBlanketOrder(SaleOrderBlanketOrderCase):
                 "The product 'Product 1' is already part of another blanket order "
                 f"{self.blanket_so.name}."
             ),
-        ):
+        ), self.env.cr.savepoint():
             order.action_confirm()
         self.product_1.allow_blanket_order_overlap = True
         order.action_confirm()

--- a/sale_order_blanket_order/tests/test_sale_call_off_order.py
+++ b/sale_order_blanket_order/tests/test_sale_call_off_order.py
@@ -103,7 +103,7 @@ class TestSaleCallOffOrder(SaleOrderBlanketOrderCase):
         with self.assertRaisesRegex(
             ValidationError,
             ("The product is not part of linked blanket order"),
-        ):
+        ), self.env.cr.savepoint():
             order.action_confirm()
 
         order = self.env["sale.order"].create(

--- a/sale_order_blanket_order/tests/test_sale_order_deliver_remaining_wizard.py
+++ b/sale_order_blanket_order/tests/test_sale_order_deliver_remaining_wizard.py
@@ -67,7 +67,7 @@ class TestSaleOrderDeliverRemainingWizard(SaleOrderBlanketOrderCase):
 
     def test_wizard_invalid_quantity(self):
         wizard = self._get_wizard(self.blanket_so)
-        with self.assertRaises(UserError):
+        with self.assertRaises(UserError), self.env.cr.savepoint():
             wizard.wizard_line_ids[0].qty_to_deliver = -1
         with self.assertRaises(UserError):
             wizard.wizard_line_ids[0].qty_to_deliver = 1000

--- a/sale_order_blanket_order/tests/test_strict_packaging.py
+++ b/sale_order_blanket_order/tests/test_strict_packaging.py
@@ -25,7 +25,7 @@ class TestStrictPackaging(SaleOrderBlanketOrderCase):
     def test_call_off_non_multiple_of_packaging(self):
         with self.assertRaisesRegex(
             ValidationError, "The product is not part of linked"
-        ):
+        ), self.env.cr.savepoint():
             call_off_so = self.env["sale.order"].create(
                 {
                     "order_type": "call_off",


### PR DESCRIPTION
…tRaises

When a test is designed to ensure that errors are detected correctly, if the error assertion does not terminate the test and the code continues to use the ORM, it is important to wrap this assertion in a savepoint to ensure that the ORM is restored to a consistent state following the error.