### PR TITLE
[16.0][FIX] sale_order_blanket_order: correct "Normal Orders" filter domain

### DIFF
--- a/sale_order_blanket_order/views/sale_order_line.xml
+++ b/sale_order_blanket_order/views/sale_order_line.xml
@@ -61,7 +61,7 @@
                 <filter
                     name="normal_orders"
                     string="Normal Orders"
-                    domain="[('order_type', '=', 'normal')]"
+                    domain="[('order_type', '=', 'order')]"
                 />
                 <filter
                     name="blanket_orders"


### PR DESCRIPTION
The "Normal Orders" filter was searching for 'normal' in the 'order_type' selection field. However, the correct technical value for standard orders is 'order'.