### PR TITLE
[18.0][FIX]  sale_order_blanket_order: fix `_compute_call_off_order_count` crash

### DIFF
--- a/sale_order_blanket_order/models/sale_order.py
+++ b/sale_order_blanket_order/models/sale_order.py
@@ -250,21 +250,19 @@ class SaleOrder(models.Model):
 
     @api.depends("call_off_order_ids")
     def _compute_call_off_order_count(self):
+        # Use _ids to see the NewId instances
         if not any(self.call_off_order_ids._ids):
             for order in self:
                 order.call_off_order_count = len(order.call_off_order_ids)
         else:
-            count_by_blanket_order_id = {
-                group["blanket_order_id"][0]: group["blanket_order_id_count"]
-                for group in self.env["sale.order"]._read_group(
-                    domain=[("blanket_order_id", "in", self._ids)],
-                    groupby=["blanket_order_id"],
-                    aggregates=["blanket_order_id:count"],
-                    order="blanket_order_id.id",
-                )
-            }
+            grouped_orders = self.env["sale.order"]._read_group(
+                domain=[("blanket_order_id", "in", self._ids)],
+                groupby=["blanket_order_id"],
+                aggregates=["blanket_order_id:count"],
+            )
+            count_by_blanket_order_id = dict(grouped_orders)
             for order in self:
-                order.call_off_order_count = count_by_blanket_order_id.get(order.id, 0)
+                order.call_off_order_count = count_by_blanket_order_id.get(order, 0)
 
     @api.depends("blanket_need_to_be_finalized", "state", "order_type")
     def _compute_is_blanket_reservation_strategy_editable(self):

--- a/sale_order_blanket_order/tests/test_sale_call_off_order.py
+++ b/sale_order_blanket_order/tests/test_sale_call_off_order.py
@@ -196,6 +196,25 @@ class TestSaleCallOffOrder(SaleOrderBlanketOrderCase):
             ],
         )
 
+    @freezegun.freeze_time("2025-02-01")
+    def test_call_off_order_count(self):
+        self.blanket_so.action_confirm()
+        self.env["sale.order"].create(
+            [
+                {
+                    "order_type": "call_off",
+                    "partner_id": self.partner.id,
+                    "blanket_order_id": self.blanket_so.id,
+                },
+                {
+                    "order_type": "call_off",
+                    "partner_id": self.partner.id,
+                    "blanket_order_id": self.blanket_so.id,
+                },
+            ]
+        )
+        self.assertEqual(self.blanket_so.call_off_order_count, 2)
+
 
 class TestSaleCallOffOrderProcessing(SaleOrderBlanketOrderCase):
     @classmethod


### PR DESCRIPTION
## Issue Solved

`_compute_call_off_order_count` crashes on 18 because `_read_group` is called the Odoo 16 way.

Error message:
> ValueError: Order term 'blanket_order_id.id' is not a valid aggregate nor valid groupby


## Changes

- Add test reproducing call_off_order_count crash
- Fixed bug by removing `order=` parameter which was not useful.