### PR TITLE
[18.0][FIX] sale_order_blanket_order: `_action_launch_stock_rule` take named parameters

### DIFF
--- a/sale_order_blanket_order/models/sale_order_line.py
+++ b/sale_order_blanket_order/models/sale_order_line.py
@@ -596,7 +596,7 @@ class SaleOrderLine(models.Model):
             call_off_lines = self.filtered(lambda line: line.order_type == "call_off")
         other_lines = self - call_off_lines
         res = super(SaleOrderLine, other_lines)._action_launch_stock_rule(
-            previous_product_uom_qty
+            previous_product_uom_qty=previous_product_uom_qty
         )
         if not self.env.context.get("call_off_split_process"):
             # When splitting a call-off line, we don't want to launch the stock rule


### PR DESCRIPTION
I noticed this bug while testing deeper.
https://github.com/OCA/sale-blanket/pull/25

## Issue Solved

`_action_launch_stock_rule` now takes its parameters named instead of positional.


Error message:
> TypeError: SaleOrderLine._action_launch_stock_rule() takes 1 positional argument but 2 were given

## Changes

- Fixed bug by changing how paremeters are passed
- Existing tests detects the issue: no need to add another