### PR TITLE
[IMP] sale_order_blanket_order_stock_prebook_release: clean up code

### DIFF
--- a/sale_order_blanket_order_stock_prebook_release/hooks.py
+++ b/sale_order_blanket_order_stock_prebook_release/hooks.py
@@ -23,7 +23,7 @@ def post_init_hook(cr, registry):
     _logger.info(
         f"Found {len(blanket_orders)} blanket orders to compute the move date priority"
     )
-    blanket_orders._compute_blanket_move_date_priority()
+    blanket_orders._set_blanket_move_date_priority()
 
     _logger.info("Setting the move date priority for the blanket orders move lines")
     for move_id in blanket_orders.order_line.move_ids:

--- a/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
+++ b/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
@@ -43,25 +43,21 @@ class SaleOrder(models.Model):
         if not blankets:
             return
 
-        # we must use plain SQL to avoid the transformation of date and datetime
-        # fields to strings done by the read_group method which is designed to
-        # be use to display data in a view... :-(
-        query = """
-            SELECT
-                blanket_validity_start_date,
-                count(1)
-            FROM
-                sale_order
-            WHERE
-                order_type = 'blanket'
-                AND state in ('sale', 'done')
-                AND blanket_validity_start_date in %s
-            GROUP BY blanket_validity_start_date
-        """
-        self.env.cr.execute(
-            query, (tuple(blankets.mapped("blanket_validity_start_date")),)
+        start_dates = blankets.mapped("blanket_validity_start_date")
+        groupby_key = "blanket_validity_start_date:day"
+        groups = self.env["sale.order"]._read_group(
+            domain=[
+                ("order_type", "=", "blanket"),
+                ("state", "in", ("sale", "done")),
+                ("blanket_validity_start_date", "in", start_dates),
+            ],
+            fields=["order_count:count(id)"],
+            groupby=[groupby_key],
         )
-        count_per_date = dict(self.env.cr.fetchall())
+        count_per_date = {
+            fields.Date.to_date(g["__range"][groupby_key]["from"]): g["order_count"]
+            for g in groups
+        }
         for order in blankets.sorted("create_date"):
             start_date = order.blanket_validity_start_date
             order_position = count_per_date.get(start_date, 0)

--- a/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
+++ b/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
@@ -21,10 +21,10 @@ class SaleOrder(models.Model):
 
     def action_confirm(self):
         self.flush_recordset()
-        self._compute_blanket_move_date_priority()
+        self._set_blanket_move_date_priority()
         return super().action_confirm()
 
-    def _compute_blanket_move_date_priority(self):
+    def _set_blanket_move_date_priority(self):
         """
         Compute the move date priority for the blanket orders.
 
@@ -77,7 +77,7 @@ class SaleOrder(models.Model):
         blanket_orders = blanket_orders.with_context(from_inverse_commitment_date=True)
 
         # Ensure we do not get back into the "_inverse_blanket_validity_start_date"
-        # since this would trigger "_compute_blanket_move_date_priority" and this
+        # since this would trigger "_set_blanket_move_date_priority" and this
         # would mess with the date priority
         for blanket_order in blanket_orders:
             blanket_order.write(
@@ -100,7 +100,7 @@ class SaleOrder(models.Model):
         for order in blanket_orders:
             order.commitment_date = order.blanket_validity_start_date
 
-        blanket_orders._compute_blanket_move_date_priority()
+        blanket_orders._set_blanket_move_date_priority()
 
         out_moves = self.env["stock.move"].search(
             [

--- a/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
+++ b/sale_order_blanket_order_stock_prebook_release/models/sale_order.py
@@ -74,13 +74,13 @@ class SaleOrder(models.Model):
         blanket_orders = self.filtered(
             lambda o: o.order_type == "blanket" and o.state != "draft"
         )
-        blanket_orders.with_context(from_inverse_commitment_date=True)
+        blanket_orders = blanket_orders.with_context(from_inverse_commitment_date=True)
 
         # Ensure we do not get back into the "_inverse_blanket_validity_start_date"
         # since this would trigger "_compute_blanket_move_date_priority" and this
         # would mess with the date priority
         for blanket_order in blanket_orders:
-            blanket_order.with_context(from_inverse_commitment_date=True).write(
+            blanket_order.write(
                 {"blanket_validity_start_date": blanket_order.commitment_date}
             )
 

--- a/sale_order_blanket_order_stock_prebook_release/tests/__init__.py
+++ b/sale_order_blanket_order_stock_prebook_release/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_hooks
+from . import test_sale_order_blanket_order_stock_prebook_release

--- a/sale_order_blanket_order_stock_prebook_release/tests/test_hooks.py
+++ b/sale_order_blanket_order_stock_prebook_release/tests/test_hooks.py
@@ -1,0 +1,33 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.sale_order_blanket_order_stock_prebook_release.hooks import (
+    post_init_hook,
+)
+
+from .common import SaleOrderBlanketOrderStockPrebookReleaseCase
+
+
+class TestPostInitHook(SaleOrderBlanketOrderStockPrebookReleaseCase):
+    def test_hook_skips_draft_and_sets_priority_for_confirmed(self):
+        """post_init_hook must compute blanket_move_date_priority only for confirmed
+        blanket orders (sale/done state) and propagate it to their moves."""
+        # Draft order must be skipped
+        self.assertFalse(self.blanket_so.blanket_move_date_priority)
+        post_init_hook(self.env.cr, self.env.registry)
+        self.assertFalse(self.blanket_so.blanket_move_date_priority)
+
+        # Confirm the order and reset priority to simulate pre-hook state
+        self.blanket_so.action_confirm()
+        self.blanket_so.write({"blanket_move_date_priority": False})
+        non_final_moves = self.blanket_so.order_line.move_ids.filtered(
+            lambda m: m.state not in ("done", "cancel", "assigned")
+        )
+        non_final_moves.write({"date_priority": False})
+
+        post_init_hook(self.env.cr, self.env.registry)
+
+        expected = self.blanket_so.blanket_move_date_priority
+        self.assertTrue(expected)
+        for move in non_final_moves:
+            self.assertEqual(move.date_priority, expected)

--- a/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
+++ b/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
@@ -215,11 +215,11 @@ class TestSaleOrderBlanketOrderStockPrebookRelease(
         with self.assertRaises(ValidationError):
             self.blanket_so.action_confirm()
 
-    def test_compute_blanket_move_date_priority_skips_without_start_date(self):
-        self.env["sale.order"]._compute_blanket_move_date_priority()
+    def test_set_blanket_move_date_priority_skips_without_start_date(self):
+        self.env["sale.order"]._set_blanket_move_date_priority()
 
         self.blanket_so.write({"blanket_validity_start_date": False})
-        self.blanket_so._compute_blanket_move_date_priority()
+        self.blanket_so._set_blanket_move_date_priority()
         self.assertFalse(self.blanket_so.blanket_move_date_priority)
 
     def test_inverse_commitment_date_updates_validity_start_date_when_confirmed(self):
@@ -237,7 +237,7 @@ class TestSaleOrderBlanketOrderStockPrebookRelease(
             new_date,
             "blanket_validity_start_date must be updated when commitment_date changes",
         )
-        # _compute_blanket_move_date_priority must NOT have been triggered again
+        # _set_blanket_move_date_priority must NOT have been triggered again
         # (the context from_inverse_commitment_date prevents it)
         self.assertEqual(
             self.blanket_so.blanket_move_date_priority,

--- a/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
+++ b/sale_order_blanket_order_stock_prebook_release/tests/test_sale_order_blanket_order_stock_prebook_release.py
@@ -94,8 +94,8 @@ class TestSaleOrderBlanketOrderStockPrebookRelease(
             ),
         )
 
-    def test_date_priority_on_prebook_moves(self):
-        """For blanket oders, the prebook moves must have the date priority set to the
+    def test_date_priority_on_prebook_moves_blanket_orders(self):
+        """For blanket orders, the prebook moves must have the date priority set to the
         blanket move date priority"""
         self.blanket_so.action_confirm()
         prebook_moves = self.blanket_so.order_line.move_ids.filtered(
@@ -107,7 +107,7 @@ class TestSaleOrderBlanketOrderStockPrebookRelease(
                 move.date_priority, self.blanket_so.blanket_move_date_priority
             )
 
-    def test_date_priority_on_prebook_moves_2(self):
+    def test_date_priority_on_prebook_moves_regular_orders(self):
         """For normal order, in case of prebooking, the date priority must be the
         datetime at confirmation"""
         new_so = self.env["sale.order"].create(
@@ -200,24 +200,129 @@ class TestSaleOrderBlanketOrderStockPrebookRelease(
         self.assertEqual(
             out_moves.date_priority.date(), self.blanket_so.blanket_validity_start_date
         )
-
-        self.blanket_so.blanket_validity_start_date = date(2025, 1, 2)
-        self.assertEqual(self.blanket_so.commitment_date.date(), date(2025, 1, 2))
+        validity_start_date = date(2025, 1, 2)
+        self.blanket_so.blanket_validity_start_date = validity_start_date
+        self.assertEqual(self.blanket_so.commitment_date.date(), validity_start_date)
         self.assertEqual(
             out_moves.date_priority.date(), self.blanket_so.blanket_validity_start_date
         )
 
     def test_confirm_dates_validation_not_broken_on_confirm(self):
-        """Ensure the dates validation occurs when confirming a blanket order.
-
-        This unit test addresses a bug where a computed field's calculation was
-        triggered before essential date validation (defined by @api.constrains).
-        The bug arose because the compute method did not account for potentially
-        empty date fields, leading to a stack trace in the UI instead of a nice
-        Validation Error pop up.
-        """
+        """Ensure the dates validation occurs when confirming a blanket order."""
         self.blanket_so.write(
             {"blanket_validity_start_date": False, "blanket_validity_end_date": False}
         )
         with self.assertRaises(ValidationError):
             self.blanket_so.action_confirm()
+
+    def test_compute_blanket_move_date_priority_skips_without_start_date(self):
+        self.env["sale.order"]._compute_blanket_move_date_priority()
+
+        self.blanket_so.write({"blanket_validity_start_date": False})
+        self.blanket_so._compute_blanket_move_date_priority()
+        self.assertFalse(self.blanket_so.blanket_move_date_priority)
+
+    def test_inverse_commitment_date_updates_validity_start_date_when_confirmed(self):
+        """Changing commitment_date on a confirmed blanket order must sync
+        blanket_validity_start_date without recomputing move date priorities."""
+        self.blanket_so.action_confirm()
+        original_priority = self.blanket_so.blanket_move_date_priority
+        self.assertTrue(original_priority)
+
+        new_date = date(2025, 3, 1)
+        self.blanket_so.commitment_date = new_date
+
+        self.assertEqual(
+            self.blanket_so.blanket_validity_start_date,
+            new_date,
+            "blanket_validity_start_date must be updated when commitment_date changes",
+        )
+        # _compute_blanket_move_date_priority must NOT have been triggered again
+        # (the context from_inverse_commitment_date prevents it)
+        self.assertEqual(
+            self.blanket_so.blanket_move_date_priority,
+            original_priority,
+            (
+                "blanket_move_date_priority must not change "
+                "when updating via commitment_date"
+            ),
+        )
+
+    def test_inverse_commitment_date_skips_draft_blanket_orders(self):
+        """Changing commitment_date on a draft blanket order must not affect
+        blanket_validity_start_date."""
+        self.assertEqual(self.blanket_so.state, "draft")
+        original_start = self.blanket_so.blanket_validity_start_date
+
+        self.blanket_so.commitment_date = date(2025, 3, 1)
+
+        self.assertEqual(
+            self.blanket_so.blanket_validity_start_date,
+            original_start,
+            "Draft blanket orders must not be affected by commitment_date inverse",
+        )
+
+    def test_inverse_blanket_validity_start_date_skips_with_context(self):
+        """_inverse_blanket_validity_start_date must return early when
+        from_inverse_commitment_date is in the context, leaving commitment_date
+        and move date_priorities untouched."""
+        self.blanket_so.action_confirm()
+        original_commitment = self.blanket_so.commitment_date
+        original_priority = self.blanket_so.blanket_move_date_priority
+
+        new_date = date(2025, 3, 1)
+        self.blanket_so.with_context(from_inverse_commitment_date=True).write(
+            {"blanket_validity_start_date": new_date}
+        )
+
+        self.assertEqual(
+            self.blanket_so.blanket_validity_start_date,
+            new_date,
+            "blanket_validity_start_date must be updated",
+        )
+        self.assertEqual(
+            self.blanket_so.commitment_date,
+            original_commitment,
+            "commitment_date must not change when from_inverse_commitment_date is set",
+        )
+        self.assertEqual(
+            self.blanket_so.blanket_move_date_priority,
+            original_priority,
+            (
+                "blanket_move_date_priority must not change "
+                "when from_inverse_commitment_date is set"
+            ),
+        )
+
+    def test_inverse_blanket_validity_start_date_skips_draft(self):
+        """_inverse_blanket_validity_start_date must not update commitment_date or
+        recompute priorities for draft blanket orders."""
+        self.assertEqual(self.blanket_so.state, "draft")
+        # Commitment date is not set on a draft order
+        self.assertFalse(self.blanket_so.commitment_date)
+
+        self.blanket_so.write({"blanket_validity_start_date": date(2025, 3, 1)})
+
+        self.assertFalse(
+            self.blanket_so.commitment_date,
+            (
+                "commitment_date must not be set by "
+                "_inverse_blanket_validity_start_date on draft"
+            ),
+        )
+        self.assertFalse(self.blanket_so.blanket_move_date_priority)
+
+    def test_prepare_procurement_values_sets_date_priority_for_blanket_at_confirm(
+        self,
+    ):
+        """_prepare_procurement_values must include date_priority equal to
+        blanket_move_date_priority for blanket orders with at_confirm strategy."""
+        self.blanket_so.action_confirm()
+        expected_priority = self.blanket_so.blanket_move_date_priority
+        self.assertTrue(expected_priority)
+
+        line = self.blanket_so.order_line[0]
+        values = line._prepare_procurement_values()
+
+        self.assertIn("date_priority", values)
+        self.assertEqual(values["date_priority"], expected_priority)


### PR DESCRIPTION
Create a few cleanups following code review made by @SilvioC2C :
https://github.com/OCA/sale-blanket/pull/29#issuecomment-4287202095

- Renamed `_compute_blanket_move_date_priority` as `_set_`  because the function is not used as a field's `compute` attribute
- Removed unused `with_context`
- Replaced raw sql query using `_read_group`

I kept the 3 changes in different commit **for now**** in case one or more changes are rejected.  
Once I know what change is accepted, I will merge the commits together.