### PR TITLE
[FIX] The widget 'Many2OneUomField' needs a 'product.product' or 'product.template' field

### DIFF
--- a/sale_blanket_order/views/sale_blanket_order_line_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_line_views.xml
@@ -125,7 +125,30 @@
                                 mode="list"
                                 readonly="1"
                                 domain="[('product_id', '=', product_id)]"
-                            />
+                            >
+                                <list string="Sale Order Lines" create="false">
+                                    <field name="order_id" />
+                                    <field name="order_partner_id" />
+                                    <field name="product_id" column_invisible="True" />
+                                    <field name="name" />
+                                    <field name="salesman_id" />
+                                    <field name="product_uom_qty" string="Qty" />
+                                    <field name="qty_delivered" />
+                                    <field name="qty_invoiced" />
+                                    <field name="qty_to_invoice" />
+                                    <field
+                                        name="product_uom_id"
+                                        groups="uom.group_uom"
+                                        widget="many2one_uom"
+                                    />
+                                    <field
+                                        name="price_subtotal"
+                                        sum="Total"
+                                        widget="monetary"
+                                    />
+                                    <field name="currency_id" column_invisible="True" />
+                                </list>
+                            </field>
                         </page>
                     </notebook>
                 </sheet>


### PR DESCRIPTION
The sale.blanket.order.line form view's "Sale Order Lines" page rendered the embedded sale_lines (sale.order.line records) using the standard sale.view_order_line_tree. That stock list view declares <field name="product_uom_id" widget="many2one_uom"/> but does not include product_id. The Many2OneUomField widget reads record.fields["product_id"] to determine the product model — when product_id isn't in
   the view's fieldset it resolves to undefined, hence the OWL lifecycle crash when navigating from the SO to the linked blanket order line form.