### PR TITLE
[19.0][FIX] sale_blanket_order: tax_ids never computed for non-blanket SO lines

### DIFF
--- a/sale_blanket_order/__manifest__.py
+++ b/sale_blanket_order/__manifest__.py
@@ -5,7 +5,7 @@
     "category": "Sale",
     "license": "AGPL-3",
     "author": "Acsone SA/NV, Odoo Community Association (OCA)",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "website": "https://github.com/OCA/sale-blanket",
     "summary": "Blanket Orders",
     "depends": ["uom", "sale_management"],

--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -136,7 +136,7 @@ class SaleOrderLine(models.Model):
         so_line_linked_bol = self.filtered("blanket_order_line.taxes_id")
         for line in so_line_linked_bol:
             line.tax_ids = line.blanket_order_line.taxes_id
-        super(SaleOrderLine, (self - so_line_linked_bol))._compute_tax_ids()
+        return super(SaleOrderLine, (self - so_line_linked_bol))._compute_tax_ids()
 
     @api.depends("blanket_order_line")
     def _compute_price_unit(self):

--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -136,7 +136,7 @@ class SaleOrderLine(models.Model):
         so_line_linked_bol = self.filtered("blanket_order_line.taxes_id")
         for line in so_line_linked_bol:
             line.tax_ids = line.blanket_order_line.taxes_id
-        return super(SaleOrderLine, (self - so_line_linked_bol))._compute_price_unit()
+        super(SaleOrderLine, (self - so_line_linked_bol))._compute_tax_ids()
 
     @api.depends("blanket_order_line")
     def _compute_price_unit(self):


### PR DESCRIPTION
## What's wrong

In `sale_blanket_order/models/sale_orders.py`, the `_compute_tax_ids` override on `sale.order.line` ends with:

```python
@api.depends("blanket_order_line")
def _compute_tax_ids(self):
    so_line_linked_bol = self.filtered("blanket_order_line.taxes_id")
    for line in so_line_linked_bol:
        line.tax_ids = line.blanket_order_line.taxes_id
    return super(SaleOrderLine, (self - so_line_linked_bol))._compute_price_unit()
                                                              ^^^^^^^^^^^^^^^^^^^^
```

The super call dispatches to `_compute_price_unit` instead of `_compute_tax_ids`. As a result, for any sale order line that is **not** linked to a blanket order line, the standard `sale.order.line._compute_tax_ids` from `sale` is never executed, and `tax_ids` (which is `store=True, precompute=True`) stays at its default empty value.

This affects every sale order line created on a database where this module is installed, regardless of whether the order has any link to a blanket order — `tax_ids` is silently empty on quotation lines even when the product has `taxes_id` set and the order's fiscal position would map them correctly.

## Reproduction

1. Install `sale_blanket_order` on a fresh 19.0 database with a chart of accounts (e.g. `l10n_nl`).
2. Open a draft sale order with a partner that has a fiscal position assigned, or rely on the auto-applied domestic one.
3. Add a product line where the product has `taxes_id` set (e.g. 21% sales tax).
4. **Expected:** the line's `Taxes` column shows the product's tax (after fiscal position mapping).
5. **Actual:** `Taxes` is empty.

Verified in `odoo-bin shell`: calling `fiscal_position.map_tax(product.taxes_id)` returns the correct tax, but the line's stored `tax_ids` stays empty because the override short-circuits the standard compute.

## Fix

Call `super()._compute_tax_ids()` instead of `super()._compute_price_unit()`. The standard Odoo compute then takes care of non-blanket lines via the normal `product.taxes_id` → `fiscal_position.map_tax()` flow.

```diff
-        return super(SaleOrderLine, (self - so_line_linked_bol))._compute_price_unit()
+        super(SaleOrderLine, (self - so_line_linked_bol))._compute_tax_ids()
```

Manifest version bumped `19.0.1.0.0` → `19.0.1.0.1`.

The companion `_compute_price_unit` override a few lines below is correct (it does call `super()._compute_price_unit()`), so this looks like a copy-paste slip introduced in the 19.0 migration (PR #15).