### PR TITLE
[16.0][FIX] sale_order_blanket_order: pass invoice/shipping addresses to call-off orders

### DIFF
--- a/sale_order_blanket_order/models/sale_order.py
+++ b/sale_order_blanket_order/models/sale_order.py
@@ -336,6 +336,8 @@ class SaleOrder(models.Model):
             self._context,
             default_blanket_order_id=self.id,
             default_partner_id=self.partner_id.id,
+            default_partner_invoice_id=self.partner_invoice_id.id,
+            default_partner_shipping_id=self.partner_shipping_id.id,
             default_order_type="call_off",
         )
         return action

--- a/sale_order_blanket_order/tests/test_sale_blanket_order.py
+++ b/sale_order_blanket_order/tests/test_sale_blanket_order.py
@@ -10,6 +10,45 @@ from .common import SaleOrderBlanketOrderCase
 
 
 class TestSaleBlanketOrder(SaleOrderBlanketOrderCase):
+    def test_action_view_call_off_orders_addresses(self):
+        partner_invoice = self.env["res.partner"].create(
+            {
+                "name": "Alternative Invoice Address",
+                "type": "invoice",
+                "parent_id": self.partner.id,
+            }
+        )
+        partner_shipping = self.env["res.partner"].create(
+            {
+                "name": "Alternative Shipping Address",
+                "type": "delivery",
+                "parent_id": self.partner.id,
+            }
+        )
+        self.blanket_so.write(
+            {
+                "partner_invoice_id": partner_invoice.id,
+                "partner_shipping_id": partner_shipping.id,
+            }
+        )
+
+        action = self.blanket_so.action_view_call_off_orders()
+        action_context = action.get("context", {})
+        with Form(self.env["sale.order"].with_context(**action_context)) as so_form:
+            with so_form.order_line.new() as line:
+                line.product_id = self.product_1
+                line.product_uom_qty = 1.0
+            call_off_order = so_form.save()
+
+        self.assertEqual(
+            call_off_order.partner_invoice_id,
+            partner_invoice,
+        )
+        self.assertEqual(
+            call_off_order.partner_shipping_id,
+            partner_shipping,
+        )
+
     def test_confirm_start_date_required(self):
         order = self.env["sale.order"].create(
             {


### PR DESCRIPTION
When generating a call-off order from a master blanket order that has manually overridden or updated invoice/shipping child addresses, the resulting call-off order defaulted back to the primary partner address.