### PR TITLE
[19.0][IMP] sale_blanket_order: add validity start date handling to sale blanket orders

### DIFF
--- a/sale_blanket_order/README.rst
+++ b/sale_blanket_order/README.rst
@@ -34,9 +34,10 @@ Sale Blanket Orders
 
 A blanket order is a pre-agreement to sell a certain number of
 quantities of products at a specific price. From a confirmed blanket
-order, the users can create new sale orders at such price, until the
-blanket order expires, either due to reaching the validity date or
-exhausting all the quantities of products.
+order, the users can create new sale orders at such price during the
+blanket order validity period, until the blanket order expires, either
+due to reaching the validity end date or exhausting all the quantities
+of products.
 
 **Table of contents**
 
@@ -80,7 +81,7 @@ introduce the following information:
 
 - Payment Terms
 
-- Validity date
+- Validity period
 
 - Order lines:
 
@@ -93,9 +94,9 @@ introduce the following information:
 |image2|
 
 From the form, once the Blanket Order has been confirmed and its state
-is open, the user can create a Sale Order, check the Sale Orders
-associated to the Blanket Order and/or see the Blanket Order lines
-associated to the BO.
+is open and the validity period has started, the user can create a Sale
+Order, check the Sale Orders associated to the Blanket Order and/or see
+the Blanket Order lines associated to the BO.
 
 |image3|
 
@@ -106,9 +107,10 @@ will be created.
 |image4|
 
 Installing this module will add an additional menu which will show all
-the blanket order lines currently defined in the system. From this list
-the user can create customized Sale Orders selecting the lines for which
-the PO (or POs if the customers are different) is (are) created.
+the blanket order lines currently defined in the system, including the
+customer for each line. From this list the user can create customized
+Sale Orders selecting the lines for which the PO (or POs if the
+customers are different) is (are) created.
 
 |image5|
 
@@ -118,7 +120,8 @@ PO line is associated. Upon adding a new product in a newly created Sale
 Order a blanket order line will be suggested depending on the following
 factors:
 
-- Closer Validity date
+- Started validity period
+- Closer scheduled date
 - Remaining quantity > Quantity introduced in the Sale Order line
 
 |image6|
@@ -167,6 +170,10 @@ Contributors
 - `Trobz <https://trobz.com>`__:
 
      - Nguyễn Minh Chiến <chien@trobz.com>
+
+- `Camptocamp <https://www.camptocamp.com>`__:
+
+     - Maksym Yankin <maksym.yankin@camptocamp.com>
 
 Other credits
 -------------

--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -79,6 +79,7 @@ class BlanketOrder(models.Model):
         copy=False,
     )
     validity_date = fields.Date()
+    validity_start_date = fields.Date()
     client_order_ref = fields.Char(
         string="Customer Reference",
         copy=False,
@@ -159,6 +160,17 @@ class BlanketOrder(models.Model):
         compute="_compute_uom_qty",
         search="_search_delivered_uom_qty",
         default=0.0,
+    )
+
+    _check_validity_dates = models.Constraint(
+        """
+        CHECK(
+            validity_start_date IS NULL
+            OR validity_date IS NULL
+            OR validity_start_date <= validity_date
+        )
+        """,
+        "The validity start date must be earlier than or equal to the validity date.",
     )
 
     def _get_sale_orders(self):
@@ -256,18 +268,19 @@ class BlanketOrder(models.Model):
             )
 
     def _validate(self):
-        try:
-            today = fields.Date.today()
-            for order in self:
-                assert order.validity_date, self.env._("Validity date is mandatory")
-                assert order.validity_date > today, self.env._(
-                    "Validity date must be in the future"
-                )
-                assert order.partner_id, self.env._("Partner is mandatory")
-                assert len(order.line_ids) > 0, self.env._("Must have some lines")
-                order.line_ids._validate()
-        except AssertionError as e:
-            raise UserError(e) from e
+        today = fields.Date.today()
+        for order in self:
+            if not order.validity_date:
+                raise UserError(self.env._("Validity date is mandatory"))
+            if order.validity_date <= today:
+                raise UserError(self.env._("Validity date must be in the future"))
+            if not order.validity_start_date:
+                raise UserError(self.env._("Validity start date is mandatory"))
+            if not order.partner_id:
+                raise UserError(self.env._("Partner is mandatory"))
+            if not order.line_ids:
+                raise UserError(self.env._("Must have some lines"))
+            order.line_ids._validate()
 
     def set_to_draft(self):
         for order in self:
@@ -600,13 +613,9 @@ class BlanketOrderLine(models.Model):
                 )
 
     def _validate(self):
-        try:
-            for line in self:
-                assert (
-                    not line.display_type and line.original_uom_qty > 0.0
-                ) or line.display_type, self.env._("Quantity must be greater than zero")
-        except AssertionError as e:
-            raise UserError(e) from e
+        for line in self.filtered(lambda line: not line.display_type):
+            if line.original_uom_qty <= 0.0:
+                raise UserError(self.env._("Quantity must be greater than zero"))
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -94,11 +94,18 @@ class SaleOrderLine(models.Model):
             return non_date_bo_lines[0]
 
     def _get_eligible_bo_lines_domain(self, base_qty):
+        today = fields.Date.today()
+        # Keep only blanket order lines that can actually satisfy this sale line:
+        # same product and currency, enough remaining quantity, open contract,
+        # and a validity period that has already started.
         filters = [
             ("product_id", "=", self.product_id.id),
             ("remaining_qty", ">=", base_qty),
             ("currency_id", "=", self.order_id.currency_id.id),
             ("order_id.state", "=", "open"),
+            "|",
+            ("order_id.validity_start_date", "=", False),
+            ("order_id.validity_start_date", "<=", today),
         ]
         if self.order_id.partner_id:
             filters.append(("partner_id", "=", self.order_id.partner_id.id))
@@ -138,19 +145,31 @@ class SaleOrderLine(models.Model):
             line.tax_ids = line.blanket_order_line.taxes_id
         return super(SaleOrderLine, (self - so_line_linked_bol))._compute_price_unit()
 
-    @api.depends("blanket_order_line")
+    def _get_blanket_order_line_price_unit(self):
+        """Return the blanket order line price in the sale line UoM."""
+        self.ensure_one()
+        if self.blanket_order_line.product_uom != self.product_uom_id:
+            return self.blanket_order_line.product_uom._compute_price(
+                self.blanket_order_line.price_unit, self.product_uom_id
+            )
+        return self.blanket_order_line.price_unit
+
+    @api.depends(
+        "blanket_order_line",
+        "product_id",
+        "product_uom_id",
+        "product_uom_qty",
+    )
     def _compute_price_unit(self):
         so_line_linked_bol = self.filtered("blanket_order_line")
         for line in so_line_linked_bol:
-            price_unit = 0
-            if line.blanket_order_line:
-                if line.blanket_order_line.product_uom != line.product_uom_id:
-                    price_unit = line.blanket_order_line.product_uom._compute_price(
-                        line.blanket_order_line.price_unit, line.product_uom_id
-                    )
-                else:
-                    price_unit = line.blanket_order_line.price_unit
-            line.price_unit = price_unit
+            price_unit = line._get_blanket_order_line_price_unit()
+            line.update(
+                {
+                    "price_unit": price_unit,
+                    "technical_price_unit": price_unit,
+                }
+            )
         return super(SaleOrderLine, (self - so_line_linked_bol))._compute_price_unit()
 
     @api.constrains("product_id")

--- a/sale_blanket_order/readme/CONTRIBUTORS.md
+++ b/sale_blanket_order/readme/CONTRIBUTORS.md
@@ -15,3 +15,7 @@
 - [Trobz](https://trobz.com):
 
   > - Nguyễn Minh Chiến \<<chien@trobz.com>\>
+
+- [Camptocamp](https://www.camptocamp.com):
+
+  > - Maksym Yankin \<<maksym.yankin@camptocamp.com>\>

--- a/sale_blanket_order/readme/DESCRIPTION.md
+++ b/sale_blanket_order/readme/DESCRIPTION.md
@@ -1,5 +1,6 @@
 A blanket order is a pre-agreement to sell a certain number of
 quantities of products at a specific price. From a confirmed blanket
-order, the users can create new sale orders at such price, until the
-blanket order expires, either due to reaching the validity date or
-exhausting all the quantities of products.
+order, the users can create new sale orders at such price during the
+blanket order validity period, until the blanket order expires, either
+due to reaching the validity end date or exhausting all the quantities
+of products.

--- a/sale_blanket_order/readme/USAGE.md
+++ b/sale_blanket_order/readme/USAGE.md
@@ -15,7 +15,7 @@ introduce the following information:
 
 - Payment Terms
 
-- Validity date
+- Validity period
 
 - Order lines:  
   - Product
@@ -27,9 +27,9 @@ introduce the following information:
 ![](../static/description/BO_form.png)
 
 From the form, once the Blanket Order has been confirmed and its state
-is open, the user can create a Sale Order, check the Sale Orders
-associated to the Blanket Order and/or see the Blanket Order lines
-associated to the BO.
+is open and the validity period has started, the user can create a Sale
+Order, check the Sale Orders associated to the Blanket Order and/or see
+the Blanket Order lines associated to the BO.
 
 ![](../static/description/BO_actions.png)
 
@@ -40,9 +40,10 @@ will be created.
 ![](../static/description/PO_from_BO.png)
 
 Installing this module will add an additional menu which will show all
-the blanket order lines currently defined in the system. From this list
-the user can create customized Sale Orders selecting the lines for which
-the PO (or POs if the customers are different) is (are) created.
+the blanket order lines currently defined in the system, including the
+customer for each line. From this list the user can create customized
+Sale Orders selecting the lines for which the PO (or POs if the
+customers are different) is (are) created.
 
 ![](../static/description/BO_lines.png)
 
@@ -52,7 +53,8 @@ PO line is associated. Upon adding a new product in a newly created Sale
 Order a blanket order line will be suggested depending on the following
 factors:
 
-- Closer Validity date
+- Started validity period
+- Closer scheduled date
 - Remaining quantity \> Quantity introduced in the Sale Order line
 
 ![](../static/description/PO_BOLine.png)

--- a/sale_blanket_order/report/templates.xml
+++ b/sale_blanket_order/report/templates.xml
@@ -26,8 +26,12 @@
                         <p t-field="doc.client_order_ref" />
                     </div>
                     <div class="col-3">
-                        <strong>Validity Date:</strong>
-                        <p t-field="doc.validity_date" />
+                        <strong>Validity Period:</strong>
+                        <p>
+                            <span t-field="doc.validity_start_date" />
+                            <span> - </span>
+                            <span t-field="doc.validity_date" />
+                        </p>
                     </div>
                     <div t-if="doc.user_id.name" class="col-3">
                         <strong>Salesperson:</strong>

--- a/sale_blanket_order/static/description/index.html
+++ b/sale_blanket_order/static/description/index.html
@@ -377,9 +377,10 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-blanket/tree/19.0/sale_blanket_order"><img alt="OCA/sale-blanket" src="https://img.shields.io/badge/github-OCA%2Fsale--blanket-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-blanket-19-0/sale-blanket-19-0-sale_blanket_order"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-blanket&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>A blanket order is a pre-agreement to sell a certain number of
 quantities of products at a specific price. From a confirmed blanket
-order, the users can create new sale orders at such price, until the
-blanket order expires, either due to reaching the validity date or
-exhausting all the quantities of products.</p>
+order, the users can create new sale orders at such price during the
+blanket order validity period, until the blanket order expires, either
+due to reaching the validity end date or exhausting all the quantities
+of products.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -424,7 +425,7 @@ introduce the following information:</p>
 <li>Vendor</li>
 <li>Salesperson</li>
 <li>Payment Terms</li>
-<li>Validity date</li>
+<li>Validity period</li>
 <li>Order lines:<ul>
 <li>Product</li>
 <li>Accorded price</li>
@@ -435,18 +436,19 @@ introduce the following information:</p>
 </ul>
 <p><img alt="image2" src="https://raw.githubusercontent.com/OCA/sale-blanket/19.0/sale_blanket_order/static/description/BO_form.png" /></p>
 <p>From the form, once the Blanket Order has been confirmed and its state
-is open, the user can create a Sale Order, check the Sale Orders
-associated to the Blanket Order and/or see the Blanket Order lines
-associated to the BO.</p>
+is open and the validity period has started, the user can create a Sale
+Order, check the Sale Orders associated to the Blanket Order and/or see
+the Blanket Order lines associated to the BO.</p>
 <p><img alt="image3" src="https://raw.githubusercontent.com/OCA/sale-blanket/19.0/sale_blanket_order/static/description/BO_actions.png" /></p>
 <p>Hitting the button Create Sale Order will open a wizard that will ask
 for the amount of each product in the BO lines for which the Sale Order
 will be created.</p>
 <p><img alt="image4" src="https://raw.githubusercontent.com/OCA/sale-blanket/19.0/sale_blanket_order/static/description/PO_from_BO.png" /></p>
 <p>Installing this module will add an additional menu which will show all
-the blanket order lines currently defined in the system. From this list
-the user can create customized Sale Orders selecting the lines for which
-the PO (or POs if the customers are different) is (are) created.</p>
+the blanket order lines currently defined in the system, including the
+customer for each line. From this list the user can create customized
+Sale Orders selecting the lines for which the PO (or POs if the
+customers are different) is (are) created.</p>
 <p><img alt="image5" src="https://raw.githubusercontent.com/OCA/sale-blanket/19.0/sale_blanket_order/static/description/BO_lines.png" /></p>
 <p>In the Sale Order form one field is added in the PO lines, the Blanket
 Order line field. This field keeps track to which Blanket Order line the
@@ -454,7 +456,8 @@ PO line is associated. Upon adding a new product in a newly created Sale
 Order a blanket order line will be suggested depending on the following
 factors:</p>
 <ul class="simple">
-<li>Closer Validity date</li>
+<li>Started validity period</li>
+<li>Closer scheduled date</li>
 <li>Remaining quantity &gt; Quantity introduced in the Sale Order line</li>
 </ul>
 <p><img alt="image6" src="https://raw.githubusercontent.com/OCA/sale-blanket/19.0/sale_blanket_order/static/description/PO_BOLine.png" /></p>
@@ -498,6 +501,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <blockquote>
 <ul class="simple">
 <li>Nguyễn Minh Chiến &lt;<a class="reference external" href="mailto:chien&#64;trobz.com">chien&#64;trobz.com</a>&gt;</li>
+</ul>
+</blockquote>
+</li>
+<li><p class="first"><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a>:</p>
+<blockquote>
+<ul class="simple">
+<li>Maksym Yankin &lt;<a class="reference external" href="mailto:maksym.yankin&#64;camptocamp.com">maksym.yankin&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </blockquote>
 </li>

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -123,10 +123,35 @@ class TestSaleBlanketOrders(SaleCommon):
     def setup_independent_user(cls):
         return None
 
+    def test_00_confirm_without_validity_start_date(self):
+        """Test blanket order confirmation requires a validity start date."""
+        blanket_order = self.blanket_order_obj.create(
+            {
+                "partner_id": self.partner.id,
+                "validity_date": self.tomorrow,
+                "payment_term_id": self.payment_term.id,
+                "pricelist_id": self.sale_pricelist.id,
+                "line_ids": [
+                    fields.Command.create(
+                        {
+                            "product_id": self.product1.id,
+                            "product_uom": self.product1.uom_id.id,
+                            "original_uom_qty": 20.0,
+                            "price_unit": 30.0,
+                        }
+                    )
+                ],
+            }
+        )
+
+        with self.assertRaisesRegex(UserError, "Validity start date is mandatory"):
+            blanket_order.action_confirm()
+
     def test_01_create_blanket_order(self):
         """We create a blanket order and check constrains to confirm BO"""
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = fields.Date.to_string(self.yesterday)
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -156,7 +181,7 @@ class TestSaleBlanketOrders(SaleCommon):
         self.assertEqual(blanket_order.state, "draft")
 
         # date in the past
-        with self.assertRaises(UserError):
+        with self.assertRaisesRegex(UserError, "Validity date must be in the future"):
             blanket_order.action_confirm()
 
         blanket_order.validity_date = fields.Date.to_string(self.tomorrow)
@@ -175,6 +200,7 @@ class TestSaleBlanketOrders(SaleCommon):
         """We create a blanket order and create two sale orders"""
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = self.tomorrow
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -237,6 +263,7 @@ class TestSaleBlanketOrders(SaleCommon):
         from the blanket order lines"""
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = self.tomorrow
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -272,6 +299,7 @@ class TestSaleBlanketOrders(SaleCommon):
         correctly assigned"""
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = self.tomorrow
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -310,6 +338,7 @@ class TestSaleBlanketOrders(SaleCommon):
         lines have been correctly assigned"""
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = self.tomorrow
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -339,6 +368,7 @@ class TestSaleBlanketOrders(SaleCommon):
         """
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = self.tomorrow
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -409,6 +439,7 @@ class TestSaleBlanketOrders(SaleCommon):
     def test_07_unlink_different_states(self):
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = self.tomorrow
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -431,6 +462,7 @@ class TestSaleBlanketOrders(SaleCommon):
         # Recreate since it was deleted
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = self.tomorrow
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -463,6 +495,7 @@ class TestSaleBlanketOrders(SaleCommon):
     def test_08_change_display_type(self):
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
             bo.validity_date = fields.Date.to_string(self.yesterday)
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -477,3 +510,47 @@ class TestSaleBlanketOrders(SaleCommon):
             UserError, "You cannot change the type of a sale order line"
         ):
             section.display_type = False
+
+    def test_09_confirm_with_zero_line_quantity(self):
+        """Test blanket order confirm rejects accountable lines without quantity."""
+        with Form(self.blanket_order_obj) as bo:
+            bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
+            bo.validity_date = self.tomorrow
+            bo.payment_term_id = self.payment_term
+            bo.pricelist_id = self.sale_pricelist
+            with bo.line_ids.new() as line:
+                line.product_id = self.product1
+                line.product_uom = self.product1.uom_id
+                line.original_uom_qty = 0.0
+                line.price_unit = 30.0
+        blanket_order = bo.save()
+
+        with self.assertRaisesRegex(UserError, "Quantity must be greater than zero"):
+            blanket_order.action_confirm()
+
+    def test_10_wizard_rejects_future_validity_start_date(self):
+        """Test sale orders cannot be created before blanket order validity starts."""
+        with Form(self.blanket_order_obj) as bo:
+            bo.partner_id = self.partner
+            bo.validity_start_date = self.tomorrow
+            bo.validity_date = self.tomorrow
+            bo.payment_term_id = self.payment_term
+            bo.pricelist_id = self.sale_pricelist
+            with bo.line_ids.new() as line:
+                line.product_id = self.product1
+                line.product_uom = self.product1.uom_id
+                line.original_uom_qty = 20.0
+                line.price_unit = 30.0
+        blanket_order = bo.save()
+        blanket_order.action_confirm()
+
+        error = "before its validity start date"
+        with self.assertRaisesRegex(UserError, error):
+            self.blanket_order_wiz_obj.with_context(
+                active_id=blanket_order.id, active_model="sale.blanket.order"
+            ).create({})
+        with self.assertRaisesRegex(UserError, error):
+            self.blanket_order_wiz_obj.with_context(
+                active_ids=blanket_order.line_ids.ids
+            ).create({})

--- a/sale_blanket_order/tests/test_sale_order.py
+++ b/sale_blanket_order/tests/test_sale_order.py
@@ -55,6 +55,7 @@ class TestSaleOrder(TestSaleCommon):
                 "default_code": "PROD_DEL03",
             }
         )
+        cls.validity_start = date.today()
         cls.validity = date.today() + timedelta(days=365)
         cls.date_schedule_1 = date.today() + timedelta(days=10)
         cls.date_schedule_2 = date.today() + timedelta(days=20)
@@ -62,6 +63,7 @@ class TestSaleOrder(TestSaleCommon):
     def create_blanket_order_01(self):
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.validity_start
             bo.validity_date = self.validity
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -83,6 +85,7 @@ class TestSaleOrder(TestSaleCommon):
     def create_blanket_order_02(self):
         with Form(self.blanket_order_obj) as bo:
             bo.partner_id = self.partner
+            bo.validity_start_date = self.validity_start
             bo.validity_date = self.validity
             bo.payment_term_id = self.payment_term
             bo.pricelist_id = self.sale_pricelist
@@ -428,3 +431,66 @@ class TestSaleOrder(TestSaleCommon):
             self.blanket_order_obj.search([("remaining_uom_qty", ">", 0)]),
             blanket_order,
         )
+
+    def test_12_sale_order_ignores_future_validity_start_date(self):
+        """Test sale order lines only use blanket orders whose validity started."""
+        blanket_order = self.create_blanket_order_02()
+        blanket_order.validity_start_date = self.validity_start + timedelta(days=1)
+        blanket_order.action_confirm()
+
+        with Form(self.sale_order_obj) as so:
+            so.partner_id = self.partner
+            with so.order_line.new() as line:
+                line.product_id = self.product_2
+                line.product_uom_qty = 5.0
+                line.price_unit = 10.0
+        sale_order = so.save()
+        self.assertFalse(sale_order.order_line.blanket_order_line)
+
+        blanket_order.validity_start_date = self.validity_start
+        with Form(self.sale_order_obj) as so:
+            so.partner_id = self.partner
+            with so.order_line.new() as line:
+                line.product_id = self.product_2
+                line.product_uom_qty = 5.0
+                line.price_unit = 10.0
+        sale_order = so.save()
+        self.assertEqual(
+            sale_order.order_line.blanket_order_line,
+            blanket_order.line_ids.filtered(
+                lambda line: line.product_id == self.product_2
+            ),
+        )
+
+    def test_13_manual_sale_order_line_uses_blanket_price_over_pricelist(self):
+        """Test manual sale lines use the blanket price instead of the pricelist."""
+        pricelist_price = 990.0
+        blanket_price = 950.0
+        self.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": self.sale_pricelist.id,
+                "product_id": self.product_2.id,
+                "compute_price": "fixed",
+                "fixed_price": pricelist_price,
+            }
+        )
+        blanket_order = self.create_blanket_order_02()
+        blanket_order_line = blanket_order.line_ids.filtered(
+            lambda line: line.product_id == self.product_2
+        )
+        blanket_order_line.price_unit = blanket_price
+        blanket_order.action_confirm()
+        self.partner.property_product_pricelist = self.sale_pricelist
+
+        with Form(self.sale_order_obj) as so:
+            so.partner_id = self.partner
+            with so.order_line.new() as line:
+                line.product_id = self.product_2
+                line.product_uom_qty = 1.0
+        sale_order = so.save()
+        sale_order_line = sale_order.order_line
+
+        self.assertEqual(sale_order_line.blanket_order_line, blanket_order_line)
+        self.assertEqual(sale_order_line.price_unit, blanket_price)
+        self.assertNotEqual(sale_order_line.price_unit, pricelist_price)
+        self.assertEqual(sale_order_line.technical_price_unit, blanket_price)

--- a/sale_blanket_order/views/sale_blanket_order_line_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_line_views.xml
@@ -9,6 +9,7 @@
             <list create="false">
                 <field name="sequence" widget="handle" />
                 <field name="order_id" />
+                <field name="partner_id" />
                 <field
                     name="product_id"
                     context="{'partner_id':parent.partner_id, 'quantity':original_uom_qty, 'company_id': company_id}"
@@ -140,6 +141,7 @@
         <field name="arch" type="xml">
             <search string="Search Sale Blanket Order Line">
                 <field name="order_id" />
+                <field name="partner_id" />
                 <field name="product_id" />
                 <field name="date_schedule" />
             </search>

--- a/sale_blanket_order/views/sale_blanket_order_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_views.xml
@@ -13,6 +13,7 @@
                 <field name="name" />
                 <field name="user_id" />
                 <field name="partner_id" />
+                <field name="validity_start_date" />
                 <field name="validity_date" />
                 <field name="state" />
                 <field
@@ -112,7 +113,14 @@
                                 options="{'no_create': True}"
                             />
                             <field name="company_id" invisible="1" />
-                            <field name="validity_date" required="state == 'draft'" />
+                            <field
+                                name="validity_start_date"
+                                string="Validity"
+                                widget="daterange"
+                                options="{'end_date_field': 'validity_date', 'always_range': 1}"
+                                required="state == 'draft'"
+                            />
+                            <field name="validity_date" invisible="1" />
                         </group>
                     </group>
                     <notebook>

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -26,7 +26,23 @@ class BlanketOrderWizard(models.TransientModel):
                     "You can't create a sale order from an expired blanket order!"
                 )
             )
+        self._check_started_blanket_orders(blanket_order)
         return blanket_order
+
+    @api.model
+    def _check_started_blanket_orders(self, blanket_orders):
+        today = fields.Date.today()
+        for blanket_order in blanket_orders.filtered(
+            lambda order: order.validity_start_date
+            and order.validity_start_date > today
+        ):
+            raise UserError(
+                self.env._(
+                    "You can't create a sale order from blanket order %(name)s "
+                    "before its validity start date.",
+                    name=blanket_order.name,
+                )
+            )
 
     @api.model
     def _check_valid_blanket_order_line(self, bo_lines):
@@ -40,6 +56,8 @@ class BlanketOrderWizard(models.TransientModel):
             for line in bo_lines
         ):
             raise UserError(self.env._("The sale has already been completed."))
+
+        self._check_started_blanket_orders(bo_lines.mapped("order_id"))
 
         for line in bo_lines:
             if line.order_id.state != "open":


### PR DESCRIPTION
Add a validity start date to sale blanket orders, exposing the validity period in the form, list, report, and documentation, and preventing sale order creation or automatic blanket line assignment before the period starts.
Also show the customer on blanket order line lists and replace assert based validation with explicit Odoo errors for clearer business validation.