### PR TITLE
[19.0][FIX] sale_blanket_order: Restored missing section options on sale order lines

### DIFF
--- a/sale_blanket_order/views/sale_order_views.xml
+++ b/sale_blanket_order/views/sale_order_views.xml
@@ -34,7 +34,7 @@
             <xpath expr="//field[@name='order_line']" position="attributes">
                 <attribute
                     name="options"
-                >{'create': [('disable_adding_lines', '=', False)]}</attribute>
+                >{'hide_composition': True, 'hide_prices': True, 'subsections': True, 'create': [('disable_adding_lines', '=', False)]}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Some options are missing from the menu of section lines in a sale order.

Normally :
<img width="170" height="230" alt="image" src="https://github.com/user-attachments/assets/7f5cbf2f-585d-41e4-8fb7-1be83c38c479" />


With sale_blanket_order installed :
<img width="156" height="151" alt="image" src="https://github.com/user-attachments/assets/728e1d0a-a7e1-4f8e-b7d0-f04678429a8d" />