### PR TITLE
[19.0][FIX] sale_blanket_order: preserve pricelist price on blanket order

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -513,14 +513,10 @@ class BlanketOrderLine(models.Model):
             currency=self.currency_id,
         )
 
-        if not self.pricelist_item_id:
-            # No pricelist rule found => no discount from pricelist
-            return pricelist_price
-
-        base_price = self._get_pricelist_price_before_discount()
-
-        # negative discounts (= surcharge) are included in the display price
-        return max(base_price, pricelist_price)
+        # Blanket order lines have no discount field where the difference between
+        # the base price and the pricelist price could be stored. The unit price
+        # must therefore keep the final price computed by the pricelist.
+        return pricelist_price
 
     def _get_pricelist_price_before_discount(self):
         # Copied and adapted from the sale module

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -196,6 +196,35 @@ class TestSaleBlanketOrders(SaleCommon):
 
         blanket_order.action_confirm()
 
+    def test_blanket_order_line_uses_fixed_pricelist_price(self):
+        self.product1.list_price = 915.0
+        fixed_price = 740.0
+        pricelist = self._create_pricelist(currency_id=self.env.ref("base.USD").id)
+        self.product_pricelist_item_obj.create(
+            {
+                "pricelist_id": pricelist.id,
+                "applied_on": "0_product_variant",
+                "product_id": self.product1.id,
+                "compute_price": "fixed",
+                "fixed_price": fixed_price,
+            }
+        )
+
+        with Form(self.blanket_order_obj) as bo:
+            bo.partner_id = self.partner
+            bo.validity_start_date = self.yesterday
+            bo.validity_date = self.tomorrow
+            bo.payment_term_id = self.payment_term
+            bo.pricelist_id = pricelist
+            with bo.line_ids.new() as line:
+                line.product_id = self.product1
+                line.product_uom = self.product1.uom_id
+                line.original_uom_qty = 1.0
+
+        blanket_order = bo.save()
+        self.assertEqual(blanket_order.line_ids.price_unit, fixed_price)
+        self.assertEqual(blanket_order.line_ids.taxes_id, self.tax1)
+
     def test_02_create_sale_orders_from_blanket_order(self):
         """We create a blanket order and create two sale orders"""
         with Form(self.blanket_order_obj) as bo:


### PR DESCRIPTION
Blanket order lines use the same display-price logic as standard sale order lines. This logic returns the price before discount when the pricelist computes a lower price, because standard sale order lines can store the difference in their discount field.
However, blanket order lines do not have a discount field. Consequently, the price before discount is stored as the unit price and the final price calculated by the pricelist is lost. 