### PR TITLE
[19.0][FIX] sale_blanket_order: tax_ids never computed for non-blanket SO lines

### DIFF
--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -143,7 +143,7 @@ class SaleOrderLine(models.Model):
         so_line_linked_bol = self.filtered("blanket_order_line.taxes_id")
         for line in so_line_linked_bol:
             line.tax_ids = line.blanket_order_line.taxes_id
-        return super(SaleOrderLine, (self - so_line_linked_bol))._compute_price_unit()
+        return super(SaleOrderLine, (self - so_line_linked_bol))._compute_tax_ids()
 
     def _get_blanket_order_line_price_unit(self):
         """Return the blanket order line price in the sale line UoM."""


### PR DESCRIPTION
Super seed https://github.com/OCA/sale-blanket/pull/41