### PR TITLE
[19.0][IMP] sale_blanket_order: Fixed quantity decimal precision and added display precision to unit price

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -136,30 +136,35 @@ class BlanketOrder(models.Model):
         compute="_compute_uom_qty",
         search="_search_original_uom_qty",
         default=0.0,
+        digits="Product Unit"
     )
     ordered_uom_qty = fields.Float(
         string="Ordered quantity",
         compute="_compute_uom_qty",
         search="_search_ordered_uom_qty",
         default=0.0,
+        digits="Product Unit"
     )
     invoiced_uom_qty = fields.Float(
         string="Invoiced quantity",
         compute="_compute_uom_qty",
         search="_search_invoiced_uom_qty",
         default=0.0,
+        digits="Product Unit"
     )
     remaining_uom_qty = fields.Float(
         string="Remaining quantity",
         compute="_compute_uom_qty",
         search="_search_remaining_uom_qty",
         default=0.0,
+        digits="Product Unit"
     )
     delivered_uom_qty = fields.Float(
         string="Delivered quantity",
         compute="_compute_uom_qty",
         search="_search_delivered_uom_qty",
         default=0.0,
+        digits="Product Unit"
     )
 
     _check_validity_dates = models.Constraint(
@@ -192,7 +197,7 @@ class BlanketOrder(models.Model):
     def _compute_state(self):
         today = fields.Date.today()
         precision = self.env["decimal.precision"].precision_get(
-            "Product Unit of Measure"
+            "Product Unit"
         )
         for order in self:
             if not order.confirmed:
@@ -419,7 +424,7 @@ class BlanketOrderLine(models.Model):
         domain=[("sale_ok", "=", True)],
     )
     product_uom = fields.Many2one("uom.uom", string="Unit of Measure")
-    price_unit = fields.Float(string="Price", digits="Product Price")
+    price_unit = fields.Float(string="Price", min_display_digits="Product Price")
     taxes_id = fields.Many2many(
         comodel_name="account.tax",
         context={"active_test": False},
@@ -427,16 +432,16 @@ class BlanketOrderLine(models.Model):
     )
     date_schedule = fields.Date(string="Scheduled Date")
     original_uom_qty = fields.Float(
-        string="Original quantity", default=1, digits="Product Unit of Measure"
+        string="Original quantity", default=1, digits="Product Unit"
     )
     ordered_uom_qty = fields.Float(
-        string="Ordered quantity", compute="_compute_quantities", store=True
+        string="Ordered quantity", compute="_compute_quantities", store=True, digits="Product Unit"
     )
     invoiced_uom_qty = fields.Float(
-        string="Invoiced quantity", compute="_compute_quantities", store=True
+        string="Invoiced quantity", compute="_compute_quantities", store=True, digits="Product Unit"
     )
     remaining_uom_qty = fields.Float(
-        string="Remaining quantity", compute="_compute_quantities", store=True
+        string="Remaining quantity", compute="_compute_quantities", store=True, digits="Product Unit"
     )
     remaining_qty = fields.Float(
         string="Remaining quantity in base UoM",
@@ -444,7 +449,7 @@ class BlanketOrderLine(models.Model):
         store=True,
     )
     delivered_uom_qty = fields.Float(
-        string="Delivered quantity", compute="_compute_quantities", store=True
+        string="Delivered quantity", compute="_compute_quantities", store=True, digits="Product Unit"
     )
     sale_lines = fields.One2many(
         "sale.order.line",
@@ -538,7 +543,7 @@ class BlanketOrderLine(models.Model):
     @api.onchange("product_id", "original_uom_qty")
     def onchange_product(self):
         precision = self.env["decimal.precision"].precision_get(
-            "Product Unit of Measure"
+            "Product Unit"
         )
         if self.product_id:
             name = self.product_id.name

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -47,7 +47,7 @@ class BlanketOrderWizard(models.TransientModel):
     @api.model
     def _check_valid_blanket_order_line(self, bo_lines):
         precision = self.env["decimal.precision"].precision_get(
-            "Product Unit of Measure"
+            "Product Unit"
         )
         company_id = False
 
@@ -246,8 +246,8 @@ class BlanketOrderWizardLine(models.TransientModel):
     )
     date_schedule = fields.Date(string="Scheduled Date")
     remaining_uom_qty = fields.Float(related="blanket_line_id.remaining_uom_qty")
-    qty = fields.Float(string="Quantity to Order", required=True)
-    price_unit = fields.Float(related="blanket_line_id.price_unit")
+    qty = fields.Float(string="Quantity to Order", required=True, digits="Product Unit")
+    price_unit = fields.Float(related="blanket_line_id.price_unit", min_display_digits="Product Price")
     currency_id = fields.Many2one("res.currency", related="blanket_line_id.currency_id")
     partner_id = fields.Many2one(
         "res.partner", related="blanket_line_id.partner_id", string="Vendor"


### PR DESCRIPTION
In Odoo 19, the default quantity decimal precision was renamed from "Product Unit of Measure" to just "Product Unit".

Also, unit price in regular sale order lines can actually write more than their decimal precision, up to 6 digits. It will not be rounded, and that line will display all 6 digits. This behaviour should also be in blanket order lines.